### PR TITLE
Fix building on Windows with MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ project(balltze
 
 set(CMAKE_CXX_STANDARD 20)
 
+# Minimum supported Windows version is 8.0
+add_definitions(-D_WIN32_WINNT=0x0602)
+
 # Set modules path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
luacstruct uses htonll() that was added in Windows 8, so define _WIN32_WINNT as 0x0602.
I could have done this only for that library, but I remember reading somewhere it is more correct to define it consistently for the whole project.